### PR TITLE
unparse not handling lack of _fields correctly

### DIFF
--- a/babyparse.js
+++ b/babyparse.js
@@ -118,7 +118,7 @@
 			{
 				if (!_input.fields)
 					_input.fields = _input.data[0] instanceof Array
-									? _input.fields
+									? _input.data[0]
 									: objectKeys(_input.data[0]);
 
 				if (!(_input.data[0] instanceof Array) && typeof _input.data[0] !== 'object')


### PR DESCRIPTION
In unparse, if we pass in an object with .data but no .fields, the results of testing for _input.data[0] is an Array is wrong.  if _input.data[0] is an Array, we should assign it to _input.fields (rather than assigning the empty _input.fields back to itself)
